### PR TITLE
bring the action into the Honeycomb OSS fold

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+
+# For anything not explicitly taken by someone else:
+* @honeycombio/api-team

--- a/.github/workflows/apply-labels.yml
+++ b/.github/workflows/apply-labels.yml
@@ -1,0 +1,10 @@
+name: Apply project labels
+on: [issues, pull_request_target, label]
+jobs:
+  apply-labels:
+    runs-on: ubuntu-latest
+    name: Apply common project labels
+    steps:
+      - uses: honeycombio/oss-management-actions/labels@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: kvrhdn/gha-buildevents@v1
+      - uses: honeycombio/gha-buildevents@v1
         with:
           apikey: ${{ secrets.BUILDEVENTS_APIKEY }}
           dataset: gha-buildevents_integration
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: kvrhdn/gha-buildevents@v1
+      - uses: honeycombio/gha-buildevents@v1
         with:
           apikey: ${{ secrets.BUILDEVENTS_APIKEY }}
           dataset: gha-buildevents_integration

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,42 @@
+# gha-buildevents changelog
+
+## v1.0.5 [2021-02-27]
+
+### Enhancements
+
+- `BUILDEVENT_FILE` is now an absolute path, allowing you to run the buildevents binary from any directory (#38). (Thanks to [@sargunv](https://github.com/sargunv)!)
+
+## v1.0.4 [2021-02-01]
+
+### Maintenance
+
+- bumped dependencies and set up Dependabot to monitor these for us from now on. | [@kvrhdn](https://github.com/kvrhdn)
+
+## v1.0.3 [2020-12-20[
+
+### Enhancements
+
+Several fixes and enhancements (again, thanks to [@DavidS](https://github.com/DavidS)!):
+
+- Improved handling of `BUILDEVENT_FILE`:
+  - If the file already exists, properties will be appended instead of overwriting the file #18
+  - The file is created during the start section, because of this every span will contain the `github.*` fields, not just the last two
+- The property `meta.source` is added to every span #19
+- The trace ID is now unique, even when re-running a workflow #20
+- Improved documentation and logging during run
+
+## v1.0.2 [2020-11-21]
+
+### Enhancements
+
+- Added the `matrix-key` input to support jobs using a matrix configuration. (Thanks to [@DavidS](https://github.com/DavidS)!)
+
+## v1.0.1 [2020-10-01]
+
+### Maintenance
+
+- Updated dependencies following the deprecation of `set-env` and `add-path` in the GitHub Actions runtime ([changelog](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)). | [@kvrhdn](https://github.com/kvrhdn)
+
+## v1.0.0 [2020-08-26]
+
+Initial release

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+This project has adopted the Honeycomb User Community Code of Conduct to clarify expected behavior in our community.
+
+https://www.honeycomb.io/honeycomb-user-community-code-of-conduct/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-All contributions are welcome, whether they are technical in nature or not. Feel free to [start a Discussion](https://github.com/kvrhdn/gha-buildevents/discussions) or [open an issue](https://github.com/kvrhdn/gha-buildevents/issues) to ask questions, discuss issues or propose enhancements.
+All contributions are welcome, whether they are technical in nature or not. Feel free to [start a Discussion](https://github.com/honeycombio/gha-buildevents/discussions) or [open an issue](https://github.com/honeycombio/gha-buildevents/issues) to ask questions, discuss issues or propose enhancements.
 
 ## Good to know
 
@@ -10,10 +10,10 @@ Before committing any code changes, execute `npm run all` to compile and package
 
 Since this project is highly dependent on both GitHub Actions and Honeycomb, it's difficult to test locally. Instead, the following workflows should be checked _manually_ to ensure functionality is not broken:
 
-- [**Integration**](https://github.com/kvrhdn/gha-buildevents/actions?query=workflow%3AIntegration): this workflow contains two jobs:
+- [**Integration**](https://github.com/honeycombio/gha-buildevents/actions?query=workflow%3AIntegration): this workflow contains two jobs:
     - **Smoke test** should create a proper trace with a couple of spans. Check to see the additional`github.*` fields are set.
     - **Matrix** is a simple workflow using a build matrix. Check each build creates a unique trace.
-- [**Integration Failure**](https://github.com/kvrhdn/gha-buildevents/actions?query=workflow%3A%22Integration+Failure%22) : this run should create a trace in Honeycomb, with `job.status` equal to `failure`.
+- [**Integration Failure**](https://github.com/honeycombio/gha-buildevents/actions?query=workflow%3A%22Integration+Failure%22) : this run should create a trace in Honeycomb, with `job.status` equal to `failure`.
 
 ## Release procedure
 
@@ -21,7 +21,7 @@ Since this project is highly dependent on both GitHub Actions and Honeycomb, it'
 
 Follow these steps to create a new release:
 
-- create a new release from [the Releases page](https://github.com/kvrhdn/gha-buildevents/releases)
+- create a new release from [the Releases page](https://github.com/honeycombio/gha-buildevents/releases)
 - assign it a tag with the new version
 - make sure to also publish the release to the GitHub Marketplace
 - update the major version tag so it points to the latest release
@@ -30,4 +30,4 @@ Follow these steps to create a new release:
 git tag -fa v1 -m "Update v1 tag"
 git push origin v1 --force
 ```
-- all tags can be seen on [the Tags page](https://github.com/kvrhdn/gha-buildevents/tags), including the commit they reference
+- all tags can be seen on [the Tags page](https://github.com/honeycombio/gha-buildevents/tags), including the commit they reference

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,6 @@
-# Contributing
+# Contributing Guide
+
+Please see our [general guide for OSS lifecycle and practices.](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md)
 
 All contributions are welcome, whether they are technical in nature or not. Feel free to [start a Discussion](https://github.com/honeycombio/gha-buildevents/discussions) or [open an issue](https://github.com/honeycombio/gha-buildevents/issues) to ask questions, discuss issues or propose enhancements.
 
@@ -14,20 +16,3 @@ Since this project is highly dependent on both GitHub Actions and Honeycomb, it'
     - **Smoke test** should create a proper trace with a couple of spans. Check to see the additional`github.*` fields are set.
     - **Matrix** is a simple workflow using a build matrix. Check each build creates a unique trace.
 - [**Integration Failure**](https://github.com/honeycombio/gha-buildevents/actions?query=workflow%3A%22Integration+Failure%22) : this run should create a trace in Honeycomb, with `job.status` equal to `failure`.
-
-## Release procedure
-
-`gha-buildevents` follows [the recommendation from the GitHub Actions team](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#versioning): each tag and release has a semantic version (i.e. `v1.0.1`). There is a major version tag (i.e. `v1`) that binds to the latest semantic version. If a new version is released, the major version tag is moved.
-
-Follow these steps to create a new release:
-
-- create a new release from [the Releases page](https://github.com/honeycombio/gha-buildevents/releases)
-- assign it a tag with the new version
-- make sure to also publish the release to the GitHub Marketplace
-- update the major version tag so it points to the latest release
-```shell
-# with the latest release checked out locally
-git tag -fa v1 -m "Update v1 tag"
-git push origin v1 --force
-```
-- all tags can be seen on [the Tags page](https://github.com/honeycombio/gha-buildevents/tags), including the commit they reference

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2019 GitHub Actions
+Copyright (c) 2022 Honeycomb
+Copyright (c) 2020-2022 Koenraad Verheyden
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/OSSMETADATA
+++ b/OSSMETADATA
@@ -1,0 +1,1 @@
+osslifecycle=maintained

--- a/README.md
+++ b/README.md
@@ -112,3 +112,7 @@ To learn more about buildevents and how to use it, checkout [honeycombio/buildev
 ## License
 
 This Action is distributed under the terms of the MIT license, see [LICENSE](./LICENSE) for details.
+
+## Contributor Alums ❤️
+
+The buildevents GitHub Action was created for the community and generously bequethed to Honeycomb by Koenraad Verheyden ([@kvrhdn](https://github.com/kvrhdn)).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # `gha-buildevents` Action
 
+[![OSS Lifecycle](https://img.shields.io/osslifecycle/honeycombio/gha-buildevents?color=success)](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md)
 [![CI](https://github.com/honeycombio/gha-buildevents/workflows/CI/badge.svg)](https://github.com/honeycombio/gha-buildevents/actions?query=workflow%3ACI)
 [![Integration](https://github.com/honeycombio/gha-buildevents/workflows/Integration/badge.svg)](https://github.com/honeycombio/gha-buildevents/actions?query=workflow%3AIntegration)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `gha-buildevents` Action
 
-[![CI](https://github.com/kvrhdn/gha-buildevents/workflows/CI/badge.svg)](https://github.com/kvrhdn/gha-buildevents/actions?query=workflow%3ACI)
-[![Integration](https://github.com/kvrhdn/gha-buildevents/workflows/Integration/badge.svg)](https://github.com/kvrhdn/gha-buildevents/actions?query=workflow%3AIntegration)
+[![CI](https://github.com/honeycombio/gha-buildevents/workflows/CI/badge.svg)](https://github.com/honeycombio/gha-buildevents/actions?query=workflow%3ACI)
+[![Integration](https://github.com/honeycombio/gha-buildevents/workflows/Integration/badge.svg)](https://github.com/honeycombio/gha-buildevents/actions?query=workflow%3AIntegration)
 
 This GitHub Action instruments your workflows using [Honeycomb's buildevents tool](https://github.com/honeycombio/buildevents). It populates the trace with metadata from the GitHub Actions environment and will always send a trace for the build, even if the build failed.
 
@@ -17,7 +17,7 @@ This GitHub Action instruments your workflows using [Honeycomb's buildevents too
 Put the action at the start of each job:
 
 ```yaml
-- uses: kvrhdn/gha-buildevents@v1
+- uses: honeycombio/gha-buildevents@v1
   with:
     # Required: a Honeycomb API key - needed to send traces.
     apikey: ${{ secrets.BUILDEVENTS_APIKEY }}
@@ -51,7 +51,7 @@ Name         | Required | Description                                          |
 
 Additionally, the following environment variable will be read:
 
-`BUILDEVENT_FILE`: the path to a file containing additional key-value pairs. Data in this file will be attached to every span sent by buildevents. If this environment variable is not set, `gha-buildevents` will set this to a location outside the working directory.  
+`BUILDEVENT_FILE`: the path to a file containing additional key-value pairs. Data in this file will be attached to every span sent by buildevents. If this environment variable is not set, `gha-buildevents` will set this to a location outside the working directory.
 When setting this environment variable, is recommended to set this [at the beginning of the workflow](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#env).
 
 ### Outputs
@@ -62,7 +62,7 @@ No outputs are set, but the following environment variables are set:
 ```
 <owner>/<repo>-<workflow>-<job>-<run number>-<random number>
 ```
-For example: `kvrhdn/gha-buildevents-Integration-smoke-test-20144-1738717406`.
+For example: `honeycombio/gha-buildevents-Integration-smoke-test-20144-1738717406`.
 
 ## Example
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,16 @@
+# Releasing
+
+`gha-buildevents` follows [the recommendation from the GitHub Actions team](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#versioning): each tag and release has a semantic version (i.e. `v1.0.1`). There is a major version tag (i.e. `v1`) that binds to the latest semantic version. If a new version is released, the major version tag is moved.
+
+Follow these steps to create a new release:
+
+- create a new release from [the Releases page](https://github.com/honeycombio/gha-buildevents/releases)
+- assign it a tag with the new version
+- make sure to also publish the release to the GitHub Marketplace
+- update the major version tag so it points to the latest release
+```shell
+# with the latest release checked out locally
+git tag -fa v1 -m "Update v1 tag"
+git push origin v1 --force
+```
+- all tags can be seen on [the Tags page](https://github.com/honeycombio/gha-buildevents/tags), including the commit they reference

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "Actions",
     "Honeycomb.io"
   ],
-  "author": "Koenraad Verheyden",
+  "author": {
+      "name": "Honeycomb",
+      "email": "support@honeycomb.io"
+  },
   "license": "MIT",
   "homepage": "https://github.com/honeycombio/gha-buildevents",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kvrhdn/gha-buildevents.git"
+    "url": "git+https://github.com/honeycombio/gha-buildevents.git"
   },
   "keywords": [
     "GitHub",
@@ -22,7 +22,7 @@
   ],
   "author": "Koenraad Verheyden",
   "license": "MIT",
-  "homepage": "https://github.com/kvrhdn/gha-buildevents",
+  "homepage": "https://github.com/honeycombio/gha-buildevents",
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.4",


### PR DESCRIPTION
* [x] appropriate files from the project template applied (contributing, license)
  * not the issue/PR templates; those are inherited from .github
* [x] lifecycle badge
* [x] default branch is `main`
* [x] PRs merge with merge commits
* [x] auto delete merged branches
* [x] Branch protection (partial until CI sorted out)
* [x] codeowners
* [x] dependabot
* [x] changelog files
* [x] .editorconfig files
* [x] github actions
    * [x] issue/PR labels
    * (deferred to future PRs) tagging, releases, publishing artifacts, etc

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202364303247792