### PR TITLE
fix integration failure workflow

### DIFF
--- a/.github/workflows/integration-failure.yaml
+++ b/.github/workflows/integration-failure.yaml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   integration:
-    name: Integration Failure
+    name: Expected Failure
     runs-on: ubuntu-latest
 
     steps:
@@ -22,4 +22,3 @@ jobs:
         run: buildevents cmd $TRACE_ID $STEP_ID sleep -- sleep 1
       - name: Expected Failure
         run: buildevents cmd $TRACE_ID $STEP_ID 'failing step' -- exit 1
-        continue-on-error: true

--- a/.github/workflows/integration-failure.yaml
+++ b/.github/workflows/integration-failure.yaml
@@ -18,5 +18,8 @@ jobs:
           job-status: ${{ job.status }}
 
       - run: echo "STEP_ID=0" >> $GITHUB_ENV
-      - run: buildevents cmd $TRACE_ID $STEP_ID sleep -- sleep 1
-      - run: buildevents cmd $TRACE_ID $STEP_ID 'failing step' -- exit 1
+      - name: Sleepy Time
+        run: buildevents cmd $TRACE_ID $STEP_ID sleep -- sleep 1
+      - name: Expected Failure
+        run: buildevents cmd $TRACE_ID $STEP_ID 'failing step' -- exit 1
+        continue-on-error: true

--- a/.github/workflows/integration-failure.yaml
+++ b/.github/workflows/integration-failure.yaml
@@ -18,5 +18,5 @@ jobs:
           job-status: ${{ job.status }}
 
       - run: echo "STEP_ID=0" >> $GITHUB_ENV
-      - run: buildevents cmd $BUILD_ID $STEP_ID sleep -- sleep 1
-      - run: buildevents cmd $BUILD_ID $STEP_ID 'failing step' -- exit 1
+      - run: buildevents cmd $TRACE_ID $STEP_ID sleep -- sleep 1
+      - run: buildevents cmd $TRACE_ID $STEP_ID 'failing step' -- exit 1


### PR DESCRIPTION
* rename BUILD_ID to TRACE_ID

This workflow fails (I think intentionally), but not because it ends with `exit 1` but because BUILD_ID is empty and buildevents complains about missing parameters.