### PR TITLE
update attribution in action metadata

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
 name: Honeycomb Buildevents
-author: Koenraad Verheyden
+author: Honeycomb
 description: Trace GitHub Action workflows with Honeycomb
 
 branding:


### PR DESCRIPTION
A followup to #109, attribute the action to Honeycomb going forward.
