### PR TITLE
[docs] Use new $GITHUB_ENV syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ To learn more about buildevents and how to use it, checkout [honeycombio/buildev
   # Record the start of the step and, for convenience, set the step ID that will
   # be used for all commands.
 - run: |
-    echo ::set-env name=STEP_ID::0
-    echo ::set-env name=STEP_START::$(date +%s)
+    echo "STEP_ID=0" >> ${GITHUB_ENV}
+    echo "STEP_START=$(date +%s)" >> ${GITHUB_ENV}
 
   # Wrap the commands that should be traced with 'buildevents cmd'
 - run: |


### PR DESCRIPTION
This was already updated for the workflows in this repo in aa8f7e6e, but I just copy-pasted the examples from this readme into my own workflow and GitHub complained about it.