### PR TITLE
use unique CIPROVIDER

### DIFF
--- a/src/buildevents.ts
+++ b/src/buildevents.ts
@@ -25,7 +25,7 @@ export async function install(apikey: string, dataset: string): Promise<void> {
 
   util.setEnv('BUILDEVENT_APIKEY', apikey)
   util.setEnv('BUILDEVENT_DATASET', dataset)
-  util.setEnv('BUILDEVENT_CIPROVIDER', 'github-actions')
+  util.setEnv('BUILDEVENT_CIPROVIDER', 'gha-buildevents')
 }
 
 export function addFields(keyValueMap: object): void {


### PR DESCRIPTION
Once https://github.com/honeycombio/buildevents/pull/160 is merged, we can use a unique CIPROVIDER (and therefore a unique User-Agent) for this package, to distinguish it from using the `buildevents` binary directly inside GHA.