### PR TITLE
Allow traces to be workflow scoped

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -13,9 +13,9 @@ inputs:
   dataset:
     description: The Honeycomb dataset to send traces to.
     required: true
-  job-status:
-    description: The job status.
-    required: true
+  status:
+    description: Status of the job or worfklow. Setting this signals when to end the trace.
+    required: false
   matrix-key:
     description: Set this to a key unique for this matrix cell, only useful when using a build matrix.
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,9 @@ inputs:
   matrix-key:
     description: Set this to a key unique for this matrix cell, only useful when using a build matrix.
     required: false
+  job-status:
+    description: Deprecated value - please use status instead
+    deprecationMessage: job-status is now deprecated - please use status instead
 
 outputs:
   trace-id:

--- a/action.yaml
+++ b/action.yaml
@@ -18,6 +18,7 @@ inputs:
     required: false
   trace-start:
     description: Unix timestamp to represent when the trace started. Not necessary for single job workflows. Send in final use of the action for multi-job workflows.
+    required: false
   matrix-key:
     description: Set this to a key unique for this matrix cell, only useful when using a build matrix.
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -23,11 +23,7 @@ inputs:
     description: Deprecated value - please use status instead
     deprecationMessage: job-status is now deprecated - please use status instead
 
-outputs:
-  trace-id:
-    description: Trace id set by the Action. Useful for workflows with multiple jobs.
-  start-timestamp:
-    description: Timestamp set by the Action. Useful for workflows with multiple jobs.
+# outputs
 
 runs:
   using: node12

--- a/action.yaml
+++ b/action.yaml
@@ -20,7 +20,11 @@ inputs:
     description: Set this to a key unique for this matrix cell, only useful when using a build matrix.
     required: false
 
-#outputs:
+outputs:
+  trace-id:
+    description: Trace id set by the Action. Useful for workflows with multiple jobs.
+  start-timestamp:
+    description: Timestamp set by the Action. Useful for workflows with multiple jobs.
 
 runs:
   using: node12

--- a/action.yaml
+++ b/action.yaml
@@ -16,6 +16,8 @@ inputs:
   status:
     description: Status of the job or worfklow. Setting this signals when to end the trace.
     required: false
+  trace-start:
+    description: Unix timestamp to represent when the trace started. Not necessary for single job workflows. Send in final use of the action for multi-job workflows.
   matrix-key:
     description: Set this to a key unique for this matrix cell, only useful when using a build matrix.
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -3808,7 +3808,9 @@ function run() {
                 util.getEnv('GITHUB_RUN_NUMBER'),
                 util.getEnv('GITHUB_RUN_ATTEMPT')
             ];
-            const traceId = core.getInput('trace-id') ? core.getInput('trace-id') : util.replaceSpaces(traceComponents.filter(value => value).join('-'));
+            const traceId = core.getInput('trace-id')
+                ? core.getInput('trace-id')
+                : util.replaceSpaces(traceComponents.filter(value => value).join('-'));
             core.info(`Trace ID: ${traceId}`);
             // set TRACE_ID to be used throughout the job
             util.setEnv('TRACE_ID', traceId);
@@ -3844,7 +3846,7 @@ function run() {
             // save buildStart to be used in the post section
             core.saveState('buildStart', buildStart.toString());
             core.saveState('isPost', 'true');
-            if (core.getInput('status')) {
+            if (core.getInput('status') || core.getInput('job-status')) {
                 core.saveState('endTrace', 'true');
             }
         }
@@ -3861,7 +3863,8 @@ function runPost() {
             const traceId = (_a = util.getEnv('TRACE_ID')) !== null && _a !== void 0 ? _a : '0';
             // use trace-start if it's provided otherwise use the start time for current job
             const traceStart = core.getInput('trace-start') ? core.getInput('trace-start') : core.getState('buildStart');
-            const workflowStatus = core.getInput('status');
+            // if status is empty, grab legacy job-status value
+            const workflowStatus = core.getInput('status') ? core.getInput('status') : core.getInput('job-status');
             const result = workflowStatus.toUpperCase() == 'SUCCESS' ? 'success' : 'failure';
             buildevents.addFields({
                 'workflow.status': workflowStatus

--- a/dist/index.js
+++ b/dist/index.js
@@ -3801,21 +3801,10 @@ function run() {
                 core.debug(`- ${key} = ${process.env[key]}`);
             }
             const buildStart = util.getTimestamp();
-            core.setOutput('start-timestamp', buildStart);
-            const traceComponents = [
-                util.getEnv('GITHUB_REPOSITORY'),
-                util.getEnv('GITHUB_WORKFLOW'),
-                util.getEnv('GITHUB_RUN_NUMBER'),
-                util.getEnv('GITHUB_RUN_ATTEMPT')
-            ];
-            const traceId = core.getInput('trace-id')
-                ? core.getInput('trace-id')
-                : util.replaceSpaces(traceComponents.filter(value => value).join('-'));
+            const traceId = buildTraceId();
             core.info(`Trace ID: ${traceId}`);
             // set TRACE_ID to be used throughout the job
             util.setEnv('TRACE_ID', traceId);
-            // set output so TRACE_ID can be passed from job to job throughout workflow
-            core.setOutput('trace-id', traceId);
             const apikey = core.getInput('apikey', { required: true });
             core.setSecret(apikey);
             const dataset = core.getInput('dataset', { required: true });
@@ -3856,11 +3845,10 @@ function run() {
     });
 }
 function runPost() {
-    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const postStart = util.getTimestamp();
-            const traceId = (_a = util.getEnv('TRACE_ID')) !== null && _a !== void 0 ? _a : '0';
+            const traceId = buildTraceId();
             // use trace-start if it's provided otherwise use the start time for current job
             const traceStart = core.getInput('trace-start') ? core.getInput('trace-start') : core.getState('buildStart');
             // if status is empty, grab legacy job-status value
@@ -3884,6 +3872,15 @@ if (!isPost) {
 }
 else if (isPost && endTrace) {
     runPost();
+}
+function buildTraceId() {
+    const traceComponents = [
+        util.getEnv('GITHUB_REPOSITORY'),
+        util.getEnv('GITHUB_WORKFLOW'),
+        util.getEnv('GITHUB_RUN_NUMBER'),
+        util.getEnv('GITHUB_RUN_ATTEMPT')
+    ];
+    return util.replaceSpaces(traceComponents.filter(value => value).join('-'));
 }
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -3801,17 +3801,19 @@ function run() {
                 core.debug(`- ${key} = ${process.env[key]}`);
             }
             const buildStart = util.getTimestamp();
+            core.setOutput('start-timestamp', buildStart);
             const traceComponents = [
                 util.getEnv('GITHUB_REPOSITORY'),
                 util.getEnv('GITHUB_WORKFLOW'),
-                util.getEnv('GITHUB_JOB'),
                 util.getEnv('GITHUB_RUN_NUMBER'),
-                core.getInput('matrix-key'),
-                // append a random number to ensure traceId is unique when the workflow is re-run
-                util.randomInt(Math.pow(2, 32)).toString()
+                util.getEnv('GITHUB_RUN_ATTEMPT')
             ];
-            const traceId = util.replaceSpaces(traceComponents.filter(value => value).join('-'));
+            const traceId = core.getInput('trace-id') ? core.getInput('trace-id') : util.replaceSpaces(traceComponents.filter(value => value).join('-'));
             core.info(`Trace ID: ${traceId}`);
+            // set TRACE_ID to be used throughout the job
+            util.setEnv('TRACE_ID', traceId);
+            // set output so TRACE_ID can be passed from job to job throughout workflow
+            core.setOutput('trace-id', traceId);
             const apikey = core.getInput('apikey', { required: true });
             core.setSecret(apikey);
             const dataset = core.getInput('dataset', { required: true });
@@ -3836,13 +3838,15 @@ function run() {
                 'meta.source': 'gha-buildevents'
             });
             // create a first step to time installation of buildevents
-            yield buildevents.step(traceId, util.randomInt(Math.pow(2, 32)).toString(), buildStart.toString(), 'gha-buildevents_init');
+            const initStepComponents = ['gha-buildevents_init', util.getEnv('GITHUB_JOB'), core.getInput('matrix-key')];
+            yield buildevents.step(traceId, util.randomInt(Math.pow(2, 32)).toString(), buildStart.toString(), util.replaceSpaces(initStepComponents.filter(value => value).join('-')));
             core.info('Init done! buildevents is now available on the path.');
-            // set TRACE_ID to be used throughout the workflow
-            util.setEnv('TRACE_ID', traceId);
             // save buildStart to be used in the post section
             core.saveState('buildStart', buildStart.toString());
             core.saveState('isPost', 'true');
+            if (core.getInput('status')) {
+                core.saveState('endTrace', 'true');
+            }
         }
         catch (error) {
             core.setFailed(error.message);
@@ -3855,14 +3859,15 @@ function runPost() {
         try {
             const postStart = util.getTimestamp();
             const traceId = (_a = util.getEnv('TRACE_ID')) !== null && _a !== void 0 ? _a : '0';
-            const buildStart = core.getState('buildStart');
-            const jobStatus = core.getInput('job-status', { required: true });
-            const result = jobStatus.toUpperCase() == 'SUCCESS' ? 'success' : 'failure';
+            // use trace-start if it's provided otherwise use the start time for current job
+            const traceStart = core.getInput('trace-start') ? core.getInput('trace-start') : core.getState('buildStart');
+            const workflowStatus = core.getInput('status');
+            const result = workflowStatus.toUpperCase() == 'SUCCESS' ? 'success' : 'failure';
             buildevents.addFields({
-                'job.status': jobStatus
+                'workflow.status': workflowStatus
             });
             yield buildevents.step(traceId, util.randomInt(Math.pow(2, 32)).toString(), postStart.toString(), 'gha-buildevents_post');
-            yield buildevents.build(traceId, buildStart, result);
+            yield buildevents.build(traceId, traceStart, result);
         }
         catch (error) {
             core.setFailed(error.message);
@@ -3870,10 +3875,11 @@ function runPost() {
     });
 }
 const isPost = !!core.getState('isPost');
+const endTrace = !!core.getState('endTrace');
 if (!isPost) {
     run();
 }
-else {
+else if (isPost && endTrace) {
     runPost();
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ async function run(): Promise<void> {
     }
 
     const buildStart = util.getTimestamp()
+    core.setOutput('start-timestamp', buildStart)
+
     const traceComponents = [
       util.getEnv('GITHUB_REPOSITORY'),
       util.getEnv('GITHUB_WORKFLOW'),
@@ -20,7 +22,11 @@ async function run(): Promise<void> {
     const traceId = util.replaceSpaces(traceComponents.filter(value => value).join('-'))
 
     core.info(`Trace ID: ${traceId}`)
-
+    // set TRACE_ID to be used throughout the job
+    util.setEnv('TRACE_ID', traceId)
+    // set output so TRACE_ID can be passed from job to job throughout workflow
+    core.setOutput('trace-id', traceId)
+    
     const apikey = core.getInput('apikey', { required: true })
     core.setSecret(apikey)
     const dataset = core.getInput('dataset', { required: true })
@@ -52,8 +58,6 @@ async function run(): Promise<void> {
 
     core.info('Init done! buildevents is now available on the path.')
 
-    // set TRACE_ID to be used throughout the workflow
-    util.setEnv('TRACE_ID', traceId)
     // save buildStart to be used in the post section
     core.saveState('buildStart', buildStart.toString())
     core.saveState('isPost', 'true')

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ async function run(): Promise<void> {
     // save buildStart to be used in the post section
     core.saveState('buildStart', buildStart.toString())
     core.saveState('isPost', 'true')
-    if (core.getInput('status')) {
+    if (core.getInput('status') || core.getInput('job-status')) {
       core.saveState('endTrace', 'true')
     }
   } catch (error) {
@@ -84,7 +84,8 @@ async function runPost(): Promise<void> {
     const traceId = util.getEnv('TRACE_ID') ?? '0'
     // use trace-start if it's provided otherwise use the start time for current job
     const traceStart = core.getInput('trace-start') ? core.getInput('trace-start') : core.getState('buildStart')
-    const workflowStatus = core.getInput('status')
+    // if status is empty, grab legacy job-status value
+    const workflowStatus = core.getInput('status') ? core.getInput('status') : core.getInput('job-status')
     const result = workflowStatus.toUpperCase() == 'SUCCESS' ? 'success' : 'failure'
 
     buildevents.addFields({

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,11 +73,11 @@ async function runPost(): Promise<void> {
     const traceId = util.getEnv('TRACE_ID') ?? '0'
     const buildStart = core.getState('buildStart')
 
-    const jobStatus = core.getInput('job-status', { required: true })
-    const result = jobStatus.toUpperCase() == 'SUCCESS' ? 'success' : 'failure'
+    const workflowStatus = core.getInput('status')
+    const result = workflowStatus.toUpperCase() == 'SUCCESS' ? 'success' : 'failure'
 
     buildevents.addFields({
-      'job.status': jobStatus
+      'workflow.status': workflowStatus
     })
 
     await buildevents.step(traceId, util.randomInt(2 ** 32).toString(), postStart.toString(), 'gha-buildevents_post')

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,11 +14,8 @@ async function run(): Promise<void> {
     const traceComponents = [
       util.getEnv('GITHUB_REPOSITORY'),
       util.getEnv('GITHUB_WORKFLOW'),
-      util.getEnv('GITHUB_JOB'),
       util.getEnv('GITHUB_RUN_NUMBER'),
-      core.getInput('matrix-key'),
-      // append a random number to ensure traceId is unique when the workflow is re-run
-      util.randomInt(2 ** 32).toString()
+      util.getEnv('GITHUB_RUN_ATTEMPT')
     ]
     const traceId = util.replaceSpaces(traceComponents.filter(value => value).join('-'))
 


### PR DESCRIPTION
This changes the inputs and logic of the action to allow for a workflow with multiple jobs to have a single trace rather than a trace per job.

The only notable change for single job workflows is job-status becomes status, but this change is also handled gracefully and it is not a breaking change. A deprecation warning has also been attached to job-status.

For a multi-job workflow, status should only be passed in the job where the trace is meant to be ended. `trace-start` should be passed along at this time as well. This can be captured from the first job in the workflow and set as an output on that job so it can accurately time the full trace.

Summary of Changes:
- traceId is now built in a way that it is workflow specific instead of job specific and the result is consistent from job to job
- job-status -> status and should only be included in the final job of a workflow. For single job workflows, there is no behavior change - just the name change.
- traceStart is an expected input on the final job of a workflow so the trace can be accurately timed. It's not necessary on single job workflows.

Example of what that looks like:
```
jobs:
  build:
    runs-on: ubuntu-latest
    env:
      PACT_CLI_IMG: pactfoundation/pact-cli:0.12.3.0
      PACT_BROKER_URL: localhost:9292
    strategy:
      fail-fast: false
      matrix:
        service: [welcome-member-email-service, special-membership-service, credit-score-service]
    steps:
      # set a timestamp to represent the start of the trace and output it so it can be used in the final job
      - name: Set trace-start
        id: set-trace-start
        run: |
          echo ::set-output name=trace-start::$(date +%s)
        if: strategy.job-index == 0 # since this is a matrix, only set the output for the first item in the matrix
      - uses: actions/checkout@v3
      - name: "Honeycomb: setup recording"
        uses: honeycombio/gha-buildevents@brookesargent.allow-multijob-trace
        with:
          apikey: ${{ secrets.BUILDEVENTS_APIKEY }}
          dataset: gha-buildevents_integration
          matrix-key: ${{ matrix.service }}
          # note status is not supplied here because we don't want to end the trace yet

      - name: Start dependencies with docker-compose
        run: docker-compose -f pact-tools/pact-broker/docker-compose.yml up -d

      - name: Set up JDK
        uses: actions/setup-java@v3.4.1
        with:
          java-version: 14
          distribution: 'adopt'

      - name: Cache
        uses: actions/cache@v3
        with:
          path: ~/.m2/repository
          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
          restore-keys: |
            ${{ runner.os }}-maven-
      - name: Start build step
        run: |
          STEP_ID=service_build-${{ matrix.service }}
          echo "STEP_ID=${STEP_ID}" >> $GITHUB_ENV
          echo "STEP_START=$(date +%s)" >> $GITHUB_ENV
      - name: Build service
        run: |
          .github/scripts/${{ matrix.service }}-build.sh
      - name: "Honeycomb: Finalise service span"
        run: buildevents step $TRACE_ID $STEP_ID $STEP_START $STEP_ID
        if: success() || failure()
      - name: Stop dependencies with docker-compose
        run: docker-compose -f pact-tools/pact-broker/docker-compose.yml down
        if: always()
    outputs:
      trace-start: ${{ steps.set-trace-start.outputs.trace-start }} # this sets the trace-start step output as a job output

  end-trace:
    runs-on: ubuntu-latest
    needs: [build]
    if: ${{ always() }}
    steps:
     - uses: technote-space/workflow-conclusion-action@v3 # this seemed like a nice action to get the workflow conclusion since it's not available as an official github context - in a single job workflow this would just be {{ job.status }}
     - name: "Honeycomb: install buildevents"
       uses: honeycombio/gha-buildevents@brookesargent.multi-job-support
       with:
         apikey: ${{ secrets.BUILDEVENTS_APIKEY }}
         dataset: gha-buildevents_integration
         status: ${{ env.WORKFLOW_CONCLUSION }} # now we use status to signal it's time to end the trace
         trace-start: ${{ needs.build.outputs.trace-start}} # we pass the timestamp from job 1 so the trace can be accurately timed
```

Corresponding trace view:
![Screen Shot 2022-09-09 at 1 31 35 PM](https://user-images.githubusercontent.com/13839757/189410691-d07ad87b-fd5a-4085-b65d-2aaab6d5a7f1.png)

