### PR TITLE
Upgrade action runtime from node12 to node16

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -23,6 +23,6 @@ inputs:
 #outputs:
 
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
   post: dist/index.js


### PR DESCRIPTION
Upgrades the runtime used to execute the action's code from node 12 (EOL) to node version 16.X