### PR TITLE
Remove plural from API secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This GitHub Action instruments your workflows using [Honeycomb's buildevents too
 - uses: honeycombio/gha-buildevents@v1
   with:
     # Required: a Honeycomb API key - needed to send traces.
-    apikey: ${{ secrets.BUILDEVENTS_APIKEY }}
+    apikey: ${{ secrets.BUILDEVENT_APIKEY }}
 
     # Required: the Honeycomb dataset to send traces to.
     dataset: gha-buildevents_integration
@@ -69,7 +69,7 @@ the-job-that-runs-first:
     - uses: honeycombio/gha-buildevents@v1
       with:
         # Required: a Honeycomb API key - needed to send traces.
-        apikey: ${{ secrets.BUILDEVENTS_APIKEY }}
+        apikey: ${{ secrets.BUILDEVENT_APIKEY }}
 
         # Required: the Honeycomb dataset to send traces to.
         dataset: gha-buildevents_integration
@@ -97,7 +97,7 @@ end-trace:
   - uses: honeycombio/gha-buildevents@v1
     with:
       # Required: a Honeycomb API key - needed to send traces.
-      apikey: ${{ secrets.BUILDEVENTS_APIKEY }}
+      apikey: ${{ secrets.BUILDEVENT_APIKEY }}
       
       # Required: the Honeycomb dataset to send traces to.
       dataset: gha-buildevents_integration


### PR DESCRIPTION
This is a bit confusing and inconsistent. In particular, in the [baseline buildevent library README](https://github.com/honeycombio/buildevents#environment-variables), it is suggested to use `BUILDEVENT_APIKEY`. And that is consistent with the [CircleCI orb docs](https://github.com/honeycombio/buildevents-orb#overview).

If people are going between the two docs it is very possible that they will introduce a hard to identify bug.

NOTE: this requires updating of the new guide. If this PR is merged, I will take that on immediately following.