### PR TITLE
[ci] send Github issues and PRs to Asana

### DIFF
--- a/.github/workflows/gh-issue-to-asana.yml
+++ b/.github/workflows/gh-issue-to-asana.yml
@@ -1,0 +1,24 @@
+name: Sync Github Issue to Asana
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  create-asana-task:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create Asana task
+        run: |
+          curl --location --request POST 'https://app.asana.com/api/1.0/tasks' \
+            --header 'Authorization: Bearer ${{ secrets.ASANA_PAT }}' \
+            --header 'Content-Type: application/json' \
+            --data-raw '{
+                "data": {
+                    "name": "${{ github.event.issue.title }}",
+                    "notes": "${{ github.event.issue.body }}\nsource: https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${{ github.event.issue.number }}",
+                    "projects": ["${{ secrets.ASANA_PROJECT_ID }}"],
+                    "assignee_section": "${{ secrets.ASANA_SECTION_ID }}",
+                    "workspace": "${{ secrets.ASANA_WORKSPACE_ID }}"
+                }
+            }'

--- a/.github/workflows/gh-issue-to-asana.yml
+++ b/.github/workflows/gh-issue-to-asana.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Create Asana task
-        uses: honeycombio/gha-create-asana-task@main
+        uses: honeycombio/gha-create-asana-task@v1.0.0
         with:
           asana-secret: ${{ secrets.ASANA_PAT }}
           asana-workspace-id: ${{ secrets.ASANA_WORKSPACE_ID }}

--- a/.github/workflows/gh-issue-to-asana.yml
+++ b/.github/workflows/gh-issue-to-asana.yml
@@ -9,16 +9,11 @@ jobs:
 
     steps:
       - name: Create Asana task
-        run: |
-          curl --location --request POST 'https://app.asana.com/api/1.0/tasks' \
-            --header 'Authorization: Bearer ${{ secrets.ASANA_PAT }}' \
-            --header 'Content-Type: application/json' \
-            --data-raw '{
-                "data": {
-                    "name": "${{ github.event.issue.title }}",
-                    "notes": "${{ github.event.issue.body }}\nsource: https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${{ github.event.issue.number }}",
-                    "projects": ["${{ secrets.ASANA_PROJECT_ID }}"],
-                    "assignee_section": "${{ secrets.ASANA_SECTION_ID }}",
-                    "workspace": "${{ secrets.ASANA_WORKSPACE_ID }}"
-                }
-            }'
+        uses: honeycombio/gha-create-asana-task@main
+        with:
+          asana-secret: ${{ secrets.ASANA_PAT }}
+          asana-workspace-id: ${{ secrets.ASANA_WORKSPACE_ID }}
+          asana-project-id: ${{ secrets.ASANA_PROJECT_ID }}
+          asana-section-id: ${{ secrets.ASANA_SECTION_ID }}
+          asana-task-name: ${{ github.event.issue.title }}
+          asana-task-description: ${{ github.event.issue.body }}

--- a/.github/workflows/gh-pr-to-asana.yml
+++ b/.github/workflows/gh-pr-to-asana.yml
@@ -1,0 +1,30 @@
+name: Sync Github Pull Request to Asana
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  create-asana-attachment-job:
+    runs-on: ubuntu-latest
+    name: Create pull request attachments on Asana tasks
+    steps:
+      - name: Create pull request attachments
+        uses: Asana/create-app-attachment-github-action@latest
+        id: postAttachment
+        with:
+          asana-secret: ${{ secrets.ASANA_SECRET }}
+      - name: Create task if not found
+        if: ${{ !contains(steps.postAttachment.outputs.status, '201') }}
+        run: |
+          curl --location --request POST 'https://app.asana.com/api/1.0/tasks' \
+            --header "Authorization: Bearer ${{ secrets.ASANA_PAT }}" \
+            --header 'Content-Type: application/json' \
+            --data-raw '{
+                "data": {
+                    "name": "${{ github.event.pull_request.title }}",
+                    "notes": "${{ github.event.pull_request.body }}\nsource: https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/pull/${{ github.event.pull_request.number }}",
+                    "projects": ["${{ secrets.ASANA_PROJECT_ID }}"],
+                    "assignee_section": "${{ secrets.ASANA_SECTION_ID }}",
+                    "workspace": "${{ secrets.ASANA_WORKSPACE_ID }}"
+                }
+            }'

--- a/.github/workflows/gh-pr-to-asana.yml
+++ b/.github/workflows/gh-pr-to-asana.yml
@@ -15,16 +15,11 @@ jobs:
           asana-secret: ${{ secrets.ASANA_SECRET }}
       - name: Create task if not found
         if: ${{ !contains(steps.postAttachment.outputs.status, '201') }}
-        run: |
-          curl --location --request POST 'https://app.asana.com/api/1.0/tasks' \
-            --header "Authorization: Bearer ${{ secrets.ASANA_PAT }}" \
-            --header 'Content-Type: application/json' \
-            --data-raw '{
-                "data": {
-                    "name": "${{ github.event.pull_request.title }}",
-                    "notes": "${{ github.event.pull_request.body }}\nsource: https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/pull/${{ github.event.pull_request.number }}",
-                    "projects": ["${{ secrets.ASANA_PROJECT_ID }}"],
-                    "assignee_section": "${{ secrets.ASANA_SECTION_ID }}",
-                    "workspace": "${{ secrets.ASANA_WORKSPACE_ID }}"
-                }
-            }'
+        uses: honeycombio/gha-create-asana-task@main
+        with:
+          asana-secret: ${{ secrets.ASANA_PAT }}
+          asana-workspace-id: ${{ secrets.ASANA_WORKSPACE_ID }}
+          asana-project-id: ${{ secrets.ASANA_PROJECT_ID }}
+          asana-section-id: ${{ secrets.ASANA_SECTION_ID }}
+          asana-task-name: ${{ github.event.pull_request.title }}
+          asana-task-description: ${{ github.event.pull_request.body }}

--- a/.github/workflows/gh-pr-to-asana.yml
+++ b/.github/workflows/gh-pr-to-asana.yml
@@ -15,7 +15,7 @@ jobs:
           asana-secret: ${{ secrets.ASANA_SECRET }}
       - name: Create task if not found
         if: ${{ !contains(steps.postAttachment.outputs.status, '201') }}
-        uses: honeycombio/gha-create-asana-task@main
+        uses: honeycombio/gha-create-asana-task@v1.0.0
         with:
           asana-secret: ${{ secrets.ASANA_PAT }}
           asana-workspace-id: ${{ secrets.ASANA_WORKSPACE_ID }}


### PR DESCRIPTION
## Which problem is this PR solving?
https://app.asana.com/0/1198607545155957/1203451723732961/f

## Short description of the changes
This adds 2 Github Actions to the repo to run on issue creation and PR opens/reopens. All issues become tasks and PRs become tasks if they don't have an Asana link in the description. These tasks go to our team board in the Inbox column.
