### PR TITLE
bugfix: repository name on Asana PR tickets

### DIFF
--- a/.github/workflows/gh-pr-to-asana.yml
+++ b/.github/workflows/gh-pr-to-asana.yml
@@ -22,7 +22,7 @@ jobs:
           asana-project-id: ${{ secrets.ASANA_PROJECT_ID }}
           asana-section-id: ${{ secrets.ASANA_SECTION_ID }}
           asana-tags: '["1203366051961930", "1170327382493643"]' # adds the tags interrupt and oncall
-          asana-task-name: '${{ github.events.repository.name}}: ${{ github.event.pull_request.title }}'
+          asana-task-name: '${{ github.event.repository.name }}: ${{ github.event.pull_request.title }}'
           asana-task-description: |
             ${{ github.event.pull_request.body }}
             source: https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/pull/${{ github.event.pull_request.number }}


### PR DESCRIPTION
Noticed the new flury of dependabot tickets didn't have the repo. name prefix properly set


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204590574192019