### PR TITLE
Add send-init-event input to allow suppressing setup event

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set trace-start
         id: set-trace-start
         run: |
-          echo ::set-output name=trace-start::$(date +%s)          
+          echo ::set-output name=trace-start::$(date +%s)
 
       - name: Buildevents
         uses: ./
@@ -46,6 +46,19 @@ jobs:
     outputs:
       trace-start: ${{ steps.set-trace-start.outputs.trace-start }}
 
+  smoke-test-without-init-event:
+    name: Smoke test without init event
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Buildevents
+        uses: ./
+        with:
+          apikey: ${{ secrets.BUILDEVENTS_APIKEY }}
+          dataset: gha-buildevents_integration
+          send-init-event: false
 
   matrix:
     name: Matrix

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This GitHub Action instruments your workflows using [Honeycomb's buildevents too
 
 ### 📣 Adopting version 2.0.0
 
-- The input field `job-status` has been renamed to `status`. This is no longer required in every job. This was done because status can now be job status or workflow status. 
+- The input field `job-status` has been renamed to `status`. This is no longer required in every job. This was done because status can now be job status or workflow status.
   We still support job-status but will give a warning that it is deprecated and encourage the switch to the status field.
 
 - `status` is no longer required in every job because including the `status` field ends a trace. For multi job workflows this is only required as part of the last job or the job that will end the trace.
@@ -60,7 +60,7 @@ In the **FIRST JOB**
 ```yaml
 the-job-that-runs-first:
   runs-on: ubuntu-latest
-  
+
   steps:
     - name: Set trace-start
       id: set-trace-start
@@ -80,7 +80,7 @@ the-job-that-runs-first:
 
   # ... the rest of your job ...
   outputs:
-      trace-start: ${{ steps.set-trace-start.outputs.trace-start }} 
+      trace-start: ${{ steps.set-trace-start.outputs.trace-start }}
 
 # ... Job 2 ...
 ```
@@ -105,7 +105,7 @@ end-trace:
     with:
       # Required: a Honeycomb API key - needed to send traces.
       apikey: ${{ secrets.BUILDEVENT_APIKEY }}
-      
+
       # Required: the Honeycomb dataset to send traces to.
       dataset: gha-buildevents_integration
 
@@ -113,11 +113,11 @@ end-trace:
         # as status of the trace.
         # Note: in V1 this was called job-status which has been deprecated
       status: ${{ env.WORKFLOW_CONCLUSION }}
-      
+
       # Optional: trace-start, this will be used in the post section and sent
       # to calculate duration of the trace. In multi job workflows, set on the final job of a workflow. Not necessary for single job workflows
       trace-start: ${{ needs.build.outputs.trace-start}}
-      
+
       # Optional: this should only be used in combination with matrix builds. Set
       # this to a value uniquely describing each matrix configuration.
       matrix-key: ${{ matrix.value }}
@@ -129,12 +129,13 @@ end-trace:
 
 ### Inputs
 
-Name         | Required | Description                                          | Type
--------------|----------|------------------------------------------------------|-------
-`apikey`     | yes      | API key used to communicate with the Honeycomb API.  | string
-`dataset`    | yes      | Honeycomb dataset to use.                            | string
-`status`     | yes      | The job or workflow status                           | string
-`matrix-key` | no       | Set this to a key unique for this matrix cell.       | string
+Name              | Required | Description                                             | Type
+------------------|----------|---------------------------------------------------------|-------
+`apikey`          | yes      | API key used to communicate with the Honeycomb API.     | string
+`dataset`         | yes      | Honeycomb dataset to use.                               | string
+`status`          | yes      | The job or workflow status                              | string
+`matrix-key`      | no       | Set this to a key unique for this matrix cell.          | string
+`send-init-event` | no       | Whether to send an event representing the action setup. | string
 
 Additionally, the following environment variable will be read:
 

--- a/action.yaml
+++ b/action.yaml
@@ -25,6 +25,10 @@ inputs:
   job-status:
     description: Deprecated value - please use status instead
     deprecationMessage: job-status is now deprecated - please use status instead
+  send-init-event:
+    default: "true"
+    description: (true/false) Whether to send an event representing the setup of this action.
+    required: false
 
 # outputs
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -191,8 +191,10 @@ function run() {
                 'meta.source': 'gha-buildevents'
             });
             // create a first step to time installation of buildevents
-            const initStepComponents = ['gha-buildevents_init', util.getEnv('GITHUB_JOB'), core.getInput('matrix-key')];
-            yield buildevents.step(traceId, util.randomInt(Math.pow(2, 32)).toString(), buildStart.toString(), util.replaceSpaces(initStepComponents.filter(value => value).join('-')));
+            if (core.getInput('send-init-event').toUpperCase() == 'TRUE') {
+                const initStepComponents = ['gha-buildevents_init', util.getEnv('GITHUB_JOB'), core.getInput('matrix-key')];
+                yield buildevents.step(traceId, util.randomInt(Math.pow(2, 32)).toString(), buildStart.toString(), util.replaceSpaces(initStepComponents.filter(value => value).join('-')));
+            }
             core.info('Init done! buildevents is now available on the path.');
             // save buildStart to be used in the post section
             core.saveState('buildStart', buildStart.toString());

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,13 +44,15 @@ async function run(): Promise<void> {
     })
 
     // create a first step to time installation of buildevents
-    const initStepComponents = ['gha-buildevents_init', util.getEnv('GITHUB_JOB'), core.getInput('matrix-key')]
-    await buildevents.step(
-      traceId,
-      util.randomInt(2 ** 32).toString(),
-      buildStart.toString(),
-      util.replaceSpaces(initStepComponents.filter(value => value).join('-'))
-    )
+    if (core.getInput('send-init-event').toUpperCase() == 'TRUE') {
+      const initStepComponents = ['gha-buildevents_init', util.getEnv('GITHUB_JOB'), core.getInput('matrix-key')]
+      await buildevents.step(
+        traceId,
+        util.randomInt(2 ** 32).toString(),
+        buildStart.toString(),
+        util.replaceSpaces(initStepComponents.filter(value => value).join('-'))
+      )
+    }
 
     core.info('Init done! buildevents is now available on the path.')
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #148 

## Short description of the changes

Adds `send-init-event` input to disable sending an event representing the action setup.

## How to verify that this has the expected result

Look at a smoke test trace and confirm the `smoke-test-without-init-event` job does not have an init event.

## Note to maintainers

You may wish to add the new smoke test job to the required checks for the repository.