### PR TITLE
Allow authorizing external PRs to use GHA secrets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,11 +5,21 @@ on:
     branches:
       - main
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
 
 jobs:
+  authorize:
+    environment:
+      ${{ github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+
   pack:
     name: CI
+    needs: authorize
     runs-on: ubuntu-latest
 
     steps:
@@ -20,6 +30,8 @@ jobs:
           status: ${{ job.status }}
 
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - run: |
           STEP_ID="install dependencies"

--- a/.github/workflows/integration-failure.yaml
+++ b/.github/workflows/integration-failure.yaml
@@ -5,15 +5,18 @@ on:
     branches:
       - main
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
 
 jobs:
   integration:
     name: Expected Failure
+    needs: authorize
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Buildevents
         uses: ./

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -5,22 +5,34 @@ on:
     branches:
       - main
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
   schedule:
     - cron: "0 * * * *" # run once every hour
 
 jobs:
+  authorize:
+    environment:
+      ${{ github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+
   smoke-test:
     name: Smoke test
+    needs: authorize
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Set trace-start
         id: set-trace-start
         run: |
-          echo ::set-output name=trace-start::$(date +%s)          
+          echo ::set-output name=trace-start::$(date +%s)
 
       - name: Buildevents
         uses: ./


### PR DESCRIPTION
Uses the setup from [this article](https://iterative.ai/blog/testing-external-contributions-using-github-actions-secrets) to configure an `authorize` step in every GHA workflow. With the `external` environment configured to require an approval before use, this should mean that PRs from external forks can be reviewed manually and then permitted to run with access to secrets like the `BUILDEVENTS_API_KEY`.

 
<img width="830" alt="Screenshot 2023-07-19 at 09 57 32" src="https://github.com/honeycombio/gha-buildevents/assets/131/35832292-af5c-4d92-ac9a-80d3029ab00e">
