### PR TITLE
feat(buildevents): make honeycomb api host optionally configurable

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -10,7 +10,7 @@ inputs:
   apikey:
     description: A Honeycomb API key - needed to send traces.
     required: true
-  api-host:
+  apihost:
     description: Defaults to https://api.honeycomb.io
     required: false
   dataset:

--- a/action.yaml
+++ b/action.yaml
@@ -13,6 +13,7 @@ inputs:
   apihost:
     description: Defaults to https://api.honeycomb.io
     required: false
+    default: https://api.honeycomb.io
   dataset:
     description: The Honeycomb dataset to send traces to.
     required: true

--- a/action.yaml
+++ b/action.yaml
@@ -10,6 +10,9 @@ inputs:
   apikey:
     description: A Honeycomb API key - needed to send traces.
     required: true
+  api-host:
+    description: Defaults to https://api.honeycomb.io
+    required: false
   dataset:
     description: The Honeycomb dataset to send traces to.
     required: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -48,7 +48,7 @@ const io = __importStar(__nccwpck_require__(7436));
 const tc = __importStar(__nccwpck_require__(7784));
 const logfmt = __importStar(__nccwpck_require__(5578));
 const util = __importStar(__nccwpck_require__(4024));
-function install(apikey, apiHost, dataset) {
+function install(apikey, apihost, dataset) {
     return __awaiter(this, void 0, void 0, function* () {
         core.info('Downloading and installing buildevents');
         const url = 'https://github.com/honeycombio/buildevents/releases/latest/download/' + util.constructExecutableName();
@@ -61,7 +61,7 @@ function install(apikey, apiHost, dataset) {
         yield exec.exec(`chmod +x ${toolPath}`);
         core.addPath(path.dirname(toolPath));
         util.setEnv('BUILDEVENT_APIKEY', apikey);
-        util.setEnv('BUILDEVENT_APIHOST', apiHost);
+        util.setEnv('BUILDEVENT_APIHOST', apihost);
         util.setEnv('BUILDEVENT_DATASET', dataset);
         util.setEnv('BUILDEVENT_CIPROVIDER', 'gha-buildevents');
     });
@@ -171,9 +171,9 @@ function run() {
             const apikey = core.getInput('apikey', { required: true });
             core.setSecret(apikey);
             // defaults to api.honeycomb.io
-            const apiHost = core.getInput('apiHost') !== '' ? core.getInput('apiHost') : 'https://api.honeycomb.io';
+            const apihost = core.getInput('apihost') !== '' ? core.getInput('apihost') : 'https://api.honeycomb.io';
             const dataset = core.getInput('dataset', { required: true });
-            yield buildevents.install(apikey, apiHost, dataset);
+            yield buildevents.install(apikey, apihost, dataset);
             buildevents.addFields({
                 // available environment variables
                 // https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables

--- a/dist/index.js
+++ b/dist/index.js
@@ -48,7 +48,7 @@ const io = __importStar(__nccwpck_require__(7436));
 const tc = __importStar(__nccwpck_require__(7784));
 const logfmt = __importStar(__nccwpck_require__(5578));
 const util = __importStar(__nccwpck_require__(4024));
-function install(apikey, dataset) {
+function install(apikey, apiHost, dataset) {
     return __awaiter(this, void 0, void 0, function* () {
         core.info('Downloading and installing buildevents');
         const url = 'https://github.com/honeycombio/buildevents/releases/latest/download/' + util.constructExecutableName();
@@ -61,6 +61,7 @@ function install(apikey, dataset) {
         yield exec.exec(`chmod +x ${toolPath}`);
         core.addPath(path.dirname(toolPath));
         util.setEnv('BUILDEVENT_APIKEY', apikey);
+        util.setEnv('BUILDEVENT_APIHOST', apiHost);
         util.setEnv('BUILDEVENT_DATASET', dataset);
         util.setEnv('BUILDEVENT_CIPROVIDER', 'gha-buildevents');
     });
@@ -169,8 +170,10 @@ function run() {
             util.setEnv('TRACE_ID', traceId);
             const apikey = core.getInput('apikey', { required: true });
             core.setSecret(apikey);
+            // defaults to api.honeycomb.io
+            const apiHost = core.getInput('apiHost') !== '' ? core.getInput('apiHost') : 'https://api.honeycomb.io';
             const dataset = core.getInput('dataset', { required: true });
-            yield buildevents.install(apikey, dataset);
+            yield buildevents.install(apikey, apiHost, dataset);
             buildevents.addFields({
                 // available environment variables
                 // https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
@@ -896,7 +899,7 @@ class OidcClient {
                 .catch(error => {
                 throw new Error(`Failed to get ID Token. \n 
         Error Code : ${error.statusCode}\n 
-        Error Message: ${error.message}`);
+        Error Message: ${error.result.message}`);
             });
             const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
             if (!id_token) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -899,7 +899,7 @@ class OidcClient {
                 .catch(error => {
                 throw new Error(`Failed to get ID Token. \n 
         Error Code : ${error.statusCode}\n 
-        Error Message: ${error.result.message}`);
+        Error Message: ${error.message}`);
             });
             const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
             if (!id_token) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -171,7 +171,7 @@ function run() {
             const apikey = core.getInput('apikey', { required: true });
             core.setSecret(apikey);
             // defaults to api.honeycomb.io
-            const apihost = core.getInput('apihost') !== '' ? core.getInput('apihost') : 'https://api.honeycomb.io';
+            const apihost = core.getInput('apihost');
             const dataset = core.getInput('dataset', { required: true });
             yield buildevents.install(apikey, apihost, dataset);
             buildevents.addFields({

--- a/src/buildevents.ts
+++ b/src/buildevents.ts
@@ -7,7 +7,7 @@ import * as tc from '@actions/tool-cache'
 import * as logfmt from 'logfmt'
 import * as util from './util'
 
-export async function install(apikey: string, apiHost: string, dataset: string): Promise<void> {
+export async function install(apikey: string, apihost: string, dataset: string): Promise<void> {
   core.info('Downloading and installing buildevents')
 
   const url = 'https://github.com/honeycombio/buildevents/releases/latest/download/' + util.constructExecutableName()
@@ -24,7 +24,7 @@ export async function install(apikey: string, apiHost: string, dataset: string):
   core.addPath(path.dirname(toolPath))
 
   util.setEnv('BUILDEVENT_APIKEY', apikey)
-  util.setEnv('BUILDEVENT_APIHOST', apiHost)
+  util.setEnv('BUILDEVENT_APIHOST', apihost)
   util.setEnv('BUILDEVENT_DATASET', dataset)
   util.setEnv('BUILDEVENT_CIPROVIDER', 'gha-buildevents')
 }

--- a/src/buildevents.ts
+++ b/src/buildevents.ts
@@ -7,7 +7,7 @@ import * as tc from '@actions/tool-cache'
 import * as logfmt from 'logfmt'
 import * as util from './util'
 
-export async function install(apikey: string, dataset: string): Promise<void> {
+export async function install(apikey: string, apiHost: string, dataset: string): Promise<void> {
   core.info('Downloading and installing buildevents')
 
   const url = 'https://github.com/honeycombio/buildevents/releases/latest/download/' + util.constructExecutableName()
@@ -24,6 +24,7 @@ export async function install(apikey: string, dataset: string): Promise<void> {
   core.addPath(path.dirname(toolPath))
 
   util.setEnv('BUILDEVENT_APIKEY', apikey)
+  util.setEnv('BUILDEVENT_APIHOST', apiHost)
   util.setEnv('BUILDEVENT_DATASET', dataset)
   util.setEnv('BUILDEVENT_CIPROVIDER', 'gha-buildevents')
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ async function run(): Promise<void> {
     const apikey = core.getInput('apikey', { required: true })
     core.setSecret(apikey)
     // defaults to api.honeycomb.io
-    const apihost = core.getInput('apihost') !== '' ? core.getInput('apihost') : 'https://api.honeycomb.io'
+    const apihost = core.getInput('apihost')
     const dataset = core.getInput('dataset', { required: true })
 
     await buildevents.install(apikey, apihost, dataset)

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,9 +19,11 @@ async function run(): Promise<void> {
 
     const apikey = core.getInput('apikey', { required: true })
     core.setSecret(apikey)
+    // defaults to api.honeycomb.io
+    const apiHost = core.getInput('apiHost') !== '' ? core.getInput('apiHost') : 'https://api.honeycomb.io'
     const dataset = core.getInput('dataset', { required: true })
 
-    await buildevents.install(apikey, dataset)
+    await buildevents.install(apikey, apiHost, dataset)
 
     buildevents.addFields({
       // available environment variables

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,10 +20,10 @@ async function run(): Promise<void> {
     const apikey = core.getInput('apikey', { required: true })
     core.setSecret(apikey)
     // defaults to api.honeycomb.io
-    const apiHost = core.getInput('apiHost') !== '' ? core.getInput('apiHost') : 'https://api.honeycomb.io'
+    const apihost = core.getInput('apihost') !== '' ? core.getInput('apihost') : 'https://api.honeycomb.io'
     const dataset = core.getInput('dataset', { required: true })
 
-    await buildevents.install(apikey, apiHost, dataset)
+    await buildevents.install(apikey, apihost, dataset)
 
     buildevents.addFields({
       // available environment variables


### PR DESCRIPTION
## Which problem is this PR solving?

https://app.asana.com/0/1198607545155957/1204760277025814/f

## Short description of the changes

Allows api host to be optionally configured for EU or Secure Tenancy customers

## How to verify that this has the expected result
I created a team in EU and then updated my fork of `microservices-testing-examples` to send to that team with the new host configuration. Then I validated the GitHub Action data made it there, it did!

![Screenshot 2023-11-28 at 2 04 52 PM](https://github.com/honeycombio/gha-buildevents/assets/13839757/3c35cee4-1e0c-4fbd-81fd-2814d91b0987)

