### PR TITLE
ci: add dependabot groups

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,3 +9,16 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      "@actions":
+        patterns:
+          - "@actions/*"
+      dev-dependencies:
+        patterns:
+          - "@types/node"
+          - "@typescript-eslint/*"
+          - "@vercel/ncc"
+          - "eslint"
+          - "js-yaml"
+          - "prettier"
+          - "typescript"


### PR DESCRIPTION
Adds some dependabot groups to keep the number of related PRs down.