### PR TITLE
chore: bump action runtime to node20

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -37,6 +37,6 @@ inputs:
 # outputs
 
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
   post: dist/index.js


### PR DESCRIPTION
## Which problem is this PR solving?

GitHub has deprecated the node16 Action runners in favor of node20.

For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

- Closes #279

