### PR TITLE
feat: add windows support

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -332,6 +332,9 @@ function constructExecutableName() {
         case 'linux':
             processPlatform = 'linux';
             break;
+        case 'win32':
+            processPlatform = 'windows';
+            break;
         default:
             throw new Error(`Unsupported platform ${process.platform}'`);
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -44,6 +44,9 @@ export function constructExecutableName(): string {
     case 'linux':
       processPlatform = 'linux'
       break
+    case 'win32':
+      processPlatform = 'windows'
+      break
     default:
       throw new Error(`Unsupported platform ${process.platform}'`)
   }


### PR DESCRIPTION
`buildevents` has had a windows binaries released since v0.14.0. We may as well support it here in the Action. 
