### PR TITLE
chore: don't use ::set-output

### DIFF
--- a/.github/workflows/integration-no-init-event.yaml
+++ b/.github/workflows/integration-no-init-event.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set trace-start
         id: set-trace-start
         run: |
-          echo ::set-output name=trace-start::$(date +%s)
+          echo "trace-start=$(date +%s)" >> $GITHUB_OUTPUT
 
       - name: Buildevents
         uses: ./

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set trace-start
         id: set-trace-start
         run: |
-          echo ::set-output name=trace-start::$(date +%s)
+          echo "trace-start=$(date +%s)" >> $GITHUB_OUTPUT
 
       - name: Buildevents
         uses: ./

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ the-job-that-runs-first:
     - name: Set trace-start
       id: set-trace-start
       run: |
-        echo ::set-output name=trace-start::$(date +%s)
+        echo "trace-start=$(date +%s)" >> $GITHUB_OUTPUT
     - uses: honeycombio/gha-buildevents@v2
       with:
         # Required: a Honeycomb API key - needed to send traces.


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #288

## Short description of the changes
Replaces `::set-output` with `$GITHUB_OUTPUT` as documented here: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## How to verify that this has the expected result
I tested the updated syntax in a separate repo and it worked. Will also validate the post-merge smoke test looks good.
