### PR TITLE
Add missing permission on End trace job

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ end-trace:
   runs-on: ubuntu-latest
   needs: [the-job-that-runs-first, job2]
   if: ${{ always() }}
+  permissions:
+    actions: read
   steps:
   - uses: technote-space/workflow-conclusion-action@v3
   - uses: honeycombio/gha-buildevents@v2


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

The "How to use it (Multi Job Workflow)" instructions are not working on a private repository.

When running the `end-trace` job, the `technote-space/workflow-conclusion-action@v3` step will fail with the following error:

```
RequestError [HttpError]: Resource not accessible by integration
    at /home/runner/work/_actions/technote-space/workflow-conclusion-action/v3/lib/main.js:85431:27
    ...
```

Based on a suggestion from users of `workflow-conclusion-action` (see https://github.com/technote-space/workflow-conclusion-action/issues/122), it seems to be because the job is missing a permission to access the action's status.

## Short description of the changes

This PR adds the `actions: read` permission on the `end-trace` job in the README

## How to verify that this has the expected result

1. Create a private repository
2. Follow the README instructions
3. See that the `end-trace` job is now successful
