### PR TITLE
feat(gha-buildevents): add otel-traceid option which md5 hashes the existing traceid format

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,15 +127,29 @@ end-trace:
 
 `gha-buildevents` is a _wrapping action_. This means it has a post section which will run at the end of the build, after all other steps. In this final step the trace is finalized using `buildevents build`. Since this step runs always, even if the job failed, you don't have to worry about traces not being sent.
 
+### OpenTelemetry-compatible Trace IDs
+
+A new input, `otel-traceid`, is available:
+
+- If set to `true`, the action will generate the trace ID as a 128-bit hex string compatible with OpenTelemetry. This is done by MD5 hashing the existing predictable trace ID (which is based on repository, workflow, run number, and run attempt). This ensures compatibility with OpenTelemetry trace ID requirements while maintaining repeatability.
+- If not set or set to `false`, the original trace ID format is used.
+
+**Example usage:**
+```yaml
+with:
+  otel-traceid: true
+```
+
 ### Inputs
 
-Name              | Required | Description                                             | Type
-------------------|----------|---------------------------------------------------------|-------
-`apikey`          | yes      | API key used to communicate with the Honeycomb API.     | string
-`dataset`         | yes      | Honeycomb dataset to use.                               | string
-`status`          | yes      | The job or workflow status                              | string
-`matrix-key`      | no       | Set this to a key unique for this matrix cell.          | string
-`send-init-event` | no       | Whether to send an event representing the action setup. | string
+Name              | Required | Description                                                                                      | Type
+------------------|----------|--------------------------------------------------------------------------------------------------|-------
+`apikey`          | yes      | API key used to communicate with the Honeycomb API.                                              | string
+`dataset`         | yes      | Honeycomb dataset to use.                                                                        | string
+`status`          | yes      | The job or workflow status                                                                       | string
+`matrix-key`      | no       | Set this to a key unique for this matrix cell.                                                   | string
+`send-init-event` | no       | Whether to send an event representing the action setup.                                          | string
+`otel-traceid`    | no       | If true, generate the trace ID as a 128-bit hex string compatible with OpenTelemetry by MD5 hashing the existing predictable trace ID. | string
 
 Additionally, the following environment variable will be read:
 
@@ -151,6 +165,8 @@ No outputs are set, but the following environment variables are set:
 <owner>/<repo>-<workflow>-<job>-<run number>-<run attempt>
 ```
 For example: `honeycombio/gha-buildevents-Integration-smoke-test-20144-1`.
+
+If the `otel-traceid` input is set to `true`, the `TRACE_ID` environment variable will instead be a 128-bit hex string (MD5 hash of the above formatted trace ID), compatible with OpenTelemetry trace ID requirements.
 
 ## Example
 

--- a/action.yaml
+++ b/action.yaml
@@ -33,6 +33,10 @@ inputs:
     default: "true"
     description: (true/false) Whether to send an event representing the setup of this action.
     required: false
+  otel-traceid:
+    description: 'If true, generate the trace ID as a 128-bit hex string compatible with OpenTelemetry by MD5 hashing the existing predictable trace ID.'
+    required: false
+    default: 'false'
 
 # outputs
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,11 @@
         "@actions/io": "^1.1.3",
         "@actions/tool-cache": "^1.6.1",
         "@types/logfmt": "^1.2.6",
-        "logfmt": "^1.4.0"
+        "logfmt": "^1.4.0",
+        "md5": "^2.3.0"
       },
       "devDependencies": {
+        "@types/md5": "^2.3.5",
         "@types/node": "^20.12.4",
         "@typescript-eslint/eslint-plugin": "^7.5.0",
         "@typescript-eslint/parser": "^7.5.0",
@@ -232,6 +234,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/md5": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/md5/-/md5-2.3.5.tgz",
+      "integrity": "sha512-/i42wjYNgE6wf0j2bcTX6kuowmdL/6PE4IVitMpm2eYKBUuYCprdcWVK+xEF0gcV6ufMCRhtxmReGfc6hIK7Jw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.12.4",
@@ -650,6 +659,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -686,6 +704,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -1159,6 +1186,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1284,6 +1317,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/merge2": {
@@ -1951,6 +1995,12 @@
         "@types/node": "*"
       }
     },
+    "@types/md5": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/md5/-/md5-2.3.5.tgz",
+      "integrity": "sha512-/i42wjYNgE6wf0j2bcTX6kuowmdL/6PE4IVitMpm2eYKBUuYCprdcWVK+xEF0gcV6ufMCRhtxmReGfc6hIK7Jw==",
+      "dev": true
+    },
     "@types/node": {
       "version": "20.12.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.4.tgz",
@@ -2222,6 +2272,11 @@
         "supports-color": "^7.1.0"
       }
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2253,6 +2308,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
     },
     "debug": {
       "version": "4.3.4",
@@ -2611,6 +2671,11 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2706,6 +2771,16 @@
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
+      }
+    },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "merge2": {

--- a/package.json
+++ b/package.json
@@ -32,11 +32,13 @@
     "@actions/io": "^1.1.3",
     "@actions/tool-cache": "^1.6.1",
     "@types/logfmt": "^1.2.6",
-    "logfmt": "^1.4.0"
+    "logfmt": "^1.4.0",
+    "md5": "^2.3.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^7.5.0",
+    "@types/md5": "^2.3.5",
     "@types/node": "^20.12.4",
+    "@typescript-eslint/eslint-plugin": "^7.5.0",
     "@typescript-eslint/parser": "^7.5.0",
     "@vercel/ncc": "^0.38.1",
     "eslint": "^8.57.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import * as core from '@actions/core'
 import * as buildevents from './buildevents.js'
 import * as util from './util.js'
+import md5 from 'md5'
 
 async function run(): Promise<void> {
   try {
@@ -112,5 +113,11 @@ function buildTraceId(): string {
     util.getEnv('GITHUB_RUN_NUMBER'),
     util.getEnv('GITHUB_RUN_ATTEMPT')
   ]
-  return util.replaceSpaces(traceComponents.filter(value => value).join('-'))
+  const rawTraceId = util.replaceSpaces(traceComponents.filter(value => value).join('-'))
+  const otelTraceIdFlag = core.getInput('otel-traceid').toLowerCase() === 'true'
+  if (otelTraceIdFlag) {
+    // md5 returns a 32-char hex string (128 bits)
+    return md5(rawTraceId)
+  }
+  return rawTraceId
 }


### PR DESCRIPTION


<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
From my original problem statement:

```
I'm currently having a problem where, I'm trying to use opentelemetry in Python in a script that's being invoked from a GitHub action.
The GHA uses https://github.com/honeycombio/gha-buildevents/tree/main which invokes https://github.com/honeycombio/buildevents/blob/main/cmd_step.go#L24 which accepts an arbitrary string as a trace_id  - using libhoney
My Python is trying to use the trace_id provided by that GHA (via buildevents) as the trace.parent_id, but Python Otel's SpanContext only accepts spec-compliant 16 byte trace IDs, and represents them as ints: https://opentelemetry-python.readthedocs.io/en/latest/api/trace.span.html#opentelemetry.trace.span.SpanContext
I've tried overriding the trace.parent_id in my code: <INTERNAL LINK REMOVED>
But it doesn't actually parent the new spans and traces to the buildevents GHA-generated trace: <LINK TO HONEYCOMB INTERNALLY REMOVED> (if you click into the traces, you can see it doesn't parent the traces with the hex IDs, which were generated by python)
```
Kind of references https://github.com/honeycombio/gha-buildevents/issues/202 I guess

## Short description of the changes
Add an `otel-traceid` option to the GHA which md5 hashes the existing traceid format to 
## How to verify that this has the expected result
Test with a github action using the new version of gha-buildevents with `otel-traceid` enabled and make sure that an otel library using application can instantiate a SpanContext with the output of the TRACE_ID now