### PR TITLE
rel: prep v3.1.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,24 @@
 # gha-buildevents changelog
 
+## v3.1.0 [2025-05-29]
+
+### Enhancements
+
+- feat(gha-buildevents): add otel-traceid option which md5 hashes the existing traceid format | [rylee fox]
+
+### Maintenance
+
+- Add missing permission on End trace job (#312) | [Thibaud Courtoison]
+- maint: update repo for pipeline team ownership (#306) | [Jamie Danielson]
+- chore: change codeowners to pipeline (#301) | [Brooke Sargent]
+- build(deps): bump honeycombio/gha-buildevents from 2 to 3 (#290) | [dependabot[bot]]
+- chore: don't use ::set-output (#299) | [Brooke Sargent]
+- build(deps-dev): bump @typescript-eslint/parser from 7.1.0 to 7.5.0 (#295) | [dependabot[bot]]
+- build(deps-dev): bump @typescript-eslint/eslint-plugin from 7.1.0 to 7.5.0 (#296) | [dependabot[bot]]
+- build(deps-dev): bump @types/node from 20.11.24 to 20.12.4 (#297) | [dependabot[bot]]
+- build(deps-dev): bump typescript from 5.3.3 to 5.4.3 (#292) | [dependabot[bot]]
+
+
 ## v3.0.0 [2024-03-01]
 
 v3 requires the `node20` action runtime.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gha-buildevents",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gha-buildevents",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gha-buildevents",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "GitHub Actions to integrate Honeycomb's buidlevents tool into your workflows",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Cuts changelog for 3.1.0 and bumps versions, per https://github.com/honeycombio/gha-buildevents/blob/main/RELEASING.md

After this:
```
Once the pull request is merged, fetch the updated main branch.
    Apply a tag for the new version on the merged commit (e.g. git tag -a v2.3.1 -m "v2.3.1")
    Push the tag upstream (this will kick off the release pipeline in CI) e.g. git push origin v2.3.1
    Create a new release from [the Releases page](https://github.com/honeycombio/gha-buildevents/releases)
        check the "Publish this release to the GitHub Marketplace" box
        choose the version tag created above
        release title matches version number
        copy and paste the changelog entry for this version into the release description
    Update the major version tag so it points to the latest release
        with the latest release checked out locally:

git tag -fa v1 -m "Update v1 tag"
git push origin v1 --force

    Review the tags on [the Tags page](https://github.com/honeycombio/gha-buildevents/tags), including the commit they reference
```