### PR TITLE
fix: preserve .exe extension when installing buildevents on Windows

### DIFF
--- a/src/buildevents.ts
+++ b/src/buildevents.ts
@@ -16,11 +16,14 @@ export async function install(apikey: string, apihost: string, dataset: string):
   const downloadPath = await tc.downloadTool(url)
 
   // rename downloaded binary - downloadPath is similar to a UUID by default
-  const toolPath = path.join(path.dirname(downloadPath), 'buildevents')
+  const exeName = process.platform === 'win32' ? 'buildevents.exe' : 'buildevents'
+  const toolPath = path.join(path.dirname(downloadPath), exeName)
   await io.mv(downloadPath, toolPath)
 
-  // make exectuable and add to path
-  await exec.exec(`chmod +x ${toolPath}`)
+  // make executable and add to path
+  if (process.platform !== 'win32') {
+    await exec.exec(`chmod +x ${toolPath}`)
+  }
   core.addPath(path.dirname(toolPath))
 
   util.setEnv('BUILDEVENT_APIKEY', apikey)


### PR DESCRIPTION
install()` in `src/buildevents.ts` renamed the downloaded binary to a
bare `buildevents`, stripping the `.exe` extension. Windows `PATHEXT`
only resolves executables with known extensions, so the binary landed
in `PATH` but could not be executed, causing:

> Unable to locate executable file: buildevents

PR #317 fixed `constructExecutableName()` in `util.ts` to append `.exe`
for win32, but `install()` was not updated to match.

- Renamed target now uses `buildevents.exe` on `win32`, `buildevents` elsewhere
- `chmod +x` is skipped on Windows where it is a no-op

**To verify:** Run the action on a Windows runner and confirm `buildevents.exe`
is found in `PATH` and executes successfully. Non-Windows runners should be unaffected.