### PR TITLE
fix: preserve .exe extension when installing buildevents on Windows

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -46,6 +46,40 @@ jobs:
     outputs:
       trace-start: ${{ steps.set-trace-start.outputs.trace-start }}
 
+  smoke-test-windows:
+    name: Smoke test (Windows)
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Buildevents
+        uses: ./
+        with:
+          apikey: ${{ secrets.BUILDEVENTS_APIKEY }}
+          dataset: gha-buildevents_integration
+
+      - name: Print contents of BUILDEVENT_FILE
+        shell: pwsh
+        run: |
+          echo "Contents of BUILDEVENT_FILE:"
+          Get-Content $env:BUILDEVENT_FILE
+
+      - shell: pwsh
+        run: |
+          $env:STEP_ID = "smoke-test-windows"
+          echo "STEP_ID=$($env:STEP_ID)" >> $env:GITHUB_ENV
+          echo "STEP_START=$([DateTimeOffset]::UtcNow.ToUnixTimeSeconds())" >> $env:GITHUB_ENV
+      - shell: pwsh
+        run: |
+          buildevents cmd $env:TRACE_ID $env:STEP_ID sleep --shell powershell.exe -- "Start-Sleep -Seconds 5"
+      - shell: pwsh
+        run: |
+          buildevents cmd $env:TRACE_ID $env:STEP_ID 'sleep some more' --shell powershell.exe -- "Start-Sleep -Seconds 2"
+      - shell: pwsh
+        run: |
+          buildevents step $env:TRACE_ID $env:STEP_ID $env:STEP_START $env:STEP_ID
+
   matrix:
     name: Matrix
     runs-on: ubuntu-latest

--- a/dist/index.js
+++ b/dist/index.js
@@ -55,10 +55,13 @@ function install(apikey, apihost, dataset) {
         core.info(`Downloading from ${url}`);
         const downloadPath = yield tc.downloadTool(url);
         // rename downloaded binary - downloadPath is similar to a UUID by default
-        const toolPath = path.join(path.dirname(downloadPath), 'buildevents');
+        const exeName = process.platform === 'win32' ? 'buildevents.exe' : 'buildevents';
+        const toolPath = path.join(path.dirname(downloadPath), exeName);
         yield io.mv(downloadPath, toolPath);
-        // make exectuable and add to path
-        yield exec.exec(`chmod +x ${toolPath}`);
+        // make executable and add to path
+        if (process.platform !== 'win32') {
+            yield exec.exec(`chmod +x ${toolPath}`);
+        }
         core.addPath(path.dirname(toolPath));
         util.setEnv('BUILDEVENT_APIKEY', apikey);
         util.setEnv('BUILDEVENT_APIHOST', apihost);

--- a/src/buildevents.ts
+++ b/src/buildevents.ts
@@ -16,11 +16,14 @@ export async function install(apikey: string, apihost: string, dataset: string):
   const downloadPath = await tc.downloadTool(url)
 
   // rename downloaded binary - downloadPath is similar to a UUID by default
-  const toolPath = path.join(path.dirname(downloadPath), 'buildevents')
+  const exeName = process.platform === 'win32' ? 'buildevents.exe' : 'buildevents'
+  const toolPath = path.join(path.dirname(downloadPath), exeName)
   await io.mv(downloadPath, toolPath)
 
-  // make exectuable and add to path
-  await exec.exec(`chmod +x ${toolPath}`)
+  // make executable and add to path
+  if (process.platform !== 'win32') {
+    await exec.exec(`chmod +x ${toolPath}`)
+  }
   core.addPath(path.dirname(toolPath))
 
   util.setEnv('BUILDEVENT_APIKEY', apikey)


### PR DESCRIPTION
## Summary

PR #332 from @muhammadarslan-techsol identified that `install()` in `buildevents.ts` renames the downloaded binary to bare `buildevents`, stripping the `.exe` extension Windows needs to resolve it via PATHEXT. Our earlier fix in #317 corrected the download URL but didn't touch the rename step.

## Changes

- Add a `smoke-test-windows` job to the Integration workflow to demonstrate the failure
- Preserve `.exe` extension when installing on Windows (cherry-picked from #332)
- Update `dist/index.js` used by runners

Related: #332, #317, #313