### PR TITLE
rel: prepare 4.0.0 release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @honeycombio/pipeline-team
+* @honeycombio/oss-maintainers

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,25 @@
 # gha-buildevents changelog
 
+## v4.0.0 [2026-04-08]
+
+v4 requires the `node24` action runtime. GitHub Action runners must have Node.js
+24 available.
+
+### Bugfixes
+
+- fix: preserve .exe extension when installing buildevents on Windows (#334) | [@muhammadarslan-techsol](https://github.com/muhammadarslan-techsol), [@robbkidd](https://github.com/robbkidd)
+
+### Maintenance
+
+- maint: upgrade to Node 24 (#333) | [@robbkidd](https://github.com/robbkidd)
+- chore: clean up CI workflows and dependabot config (#335) | [@robbkidd](https://github.com/robbkidd)
+- ci: fix permissions on workflows (#341) | [@codeboten](https://github.com/codeboten)
+- maint: less noisy dependabot groupings (#342) | [@robbkidd](https://github.com/robbkidd)
+- build(deps-dev): bump the patch-and-minor group across 1 directory with 4 updates (#343) | [dependabot[bot]]
+- build(deps): bump the major-actions group across 1 directory with 4 updates (#344) | [dependabot[bot]]
+- build(deps-dev): bump the major-typescript-eslint group across 1 directory with 2 updates (#345) | [dependabot[bot]]
+- build(deps-dev): bump @types/node from 24.12.2 to 25.3.5 in the major-types group (#346) | [dependabot[bot]]
+
 ## v3.1.1 [2025-08-25]
 
 ### Maintenance

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gha-buildevents",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gha-buildevents",
-      "version": "3.1.1",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gha-buildevents",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "description": "GitHub Actions to integrate Honeycomb's buidlevents tool into your workflows",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## Summary

Prepare the v4.0.0 release. New major release because the minimum Node runtime moves from 20 to 24. GitHub Action runners will need to have Node.js 24 available.

BONUS: include a CODEOWNERS update.